### PR TITLE
Added Autoprefixer to gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ var imagemin = require('gulp-imagemin');
 var cache = require('gulp-cache');
 var del = require('del');
 var runSequence = require('run-sequence').use(gulp);
+var autoprefixer = require('gulp-autoprefixer');
 
 gulp.task('browserSync', function() {
     browserSync.init({
@@ -21,6 +22,7 @@ gulp.task('browserSync', function() {
 gulp.task('sass', function() {
     return gulp.src('app/scss/**/*.scss') //Source all files ending with.scss in scss directory and its subdirectories
       .pipe(sass())
+      .pipe(autoprefixer())
       .pipe(gulp.dest('app/css'))
       .pipe(browserSync.reload({
           stream: true


### PR DESCRIPTION
Write your CSS rules without vendor prefixes (in fact, forget about them entirely), Autoprefixer add vendor prefixes to CSS rules for you.

